### PR TITLE
Dynamic settings

### DIFF
--- a/api/get_index.js
+++ b/api/get_index.js
@@ -49,11 +49,11 @@ module.exports = _ => ({
     decodeToken(req.query.child_token).then(token => {
       fetchUsersFromToken(token).then(({currentUser, matchingUsers}) => {
         reply(indexTemplate({
+          dynamicSettings,
           stylesheetLink,
           currentUser,
           matchingUsers,
-          customCSS: config('CUSTOM_CSS'),
-          dynamicSettings
+          customCSS: config('CUSTOM_CSS')
         }));
       })
       .catch(err => {

--- a/api/get_index.js
+++ b/api/get_index.js
@@ -67,11 +67,11 @@ module.exports = _ => ({
       console.error("An invalid token was provided", err);
 
       indexTemplate({
+        dynamicSettings,
         stylesheetLink,
         currentUser: null,
         matchingUsers: [],
-        customCSS: config('CUSTOM_CSS'),
-        dynamicSettings  
+        customCSS: config('CUSTOM_CSS')
       }).then((template) => {
         reply(template).code(400);
       });

--- a/api/get_index.js
+++ b/api/get_index.js
@@ -39,13 +39,21 @@ module.exports = _ => ({
 
     const stylesheetLink = config('NODE_ENV') === 'production' ? CDN_CSS : '/css/link.css';
 
+    const dynamicSettings = {};
+
+    if (req.query.locale) dynamicSettings.locale = req.query.locale;
+    if (req.query.color) dynamicSettings.color = '#' + req.query.color;
+    if (req.query.title) dynamicSettings.title = req.query.title;
+    if (req.query.logoPath) dynamicSettings.logoPath = req.query.logoPath;
+
     decodeToken(req.query.child_token).then(token => {
       fetchUsersFromToken(token).then(({currentUser, matchingUsers}) => {
         reply(indexTemplate({
           stylesheetLink,
           currentUser,
           matchingUsers,
-          customCSS: config('CUSTOM_CSS')
+          customCSS: config('CUSTOM_CSS'),
+          dynamicSettings
         }));
       })
       .catch(err => {
@@ -62,7 +70,8 @@ module.exports = _ => ({
         stylesheetLink,
         currentUser: null,
         matchingUsers: [],
-        customCSS: config('CUSTOM_CSS')
+        customCSS: config('CUSTOM_CSS'),
+        dynamicSettings  
       }).then((template) => {
         reply(template).code(400);
       });

--- a/lib/locale.js
+++ b/lib/locale.js
@@ -3,25 +3,16 @@ import jsonLocales from '../locales.json';
 
 export const allLocales = jsonLocales;
 
-let _settings = null;
-
-function resolveLocale(key) {
-  const locales = allLocales[_settings.locale];
-
-  let locale = locales[key];
-
-  if (typeof locale === 'undefined') {
-    locale = allLocales.en[key];
+export default function resolveLocale(locale) {
+  return function resolve(key) {
+    const locales = allLocales[locale];
+    
+      let localeStr = locales[key];
+    
+      if (typeof localeStr === 'undefined') {
+        localeStr = allLocales.en[key];
+      }
+    
+      return localeStr;
   }
-
-  return locale;
 }
-
-export default () =>
-  new Promise((resolve) => {
-    getSettings()
-      .then((settings) => {
-        _settings = settings;
-      })
-      .then(resolve(resolveLocale));
-  });

--- a/lib/locale.js
+++ b/lib/locale.js
@@ -3,16 +3,16 @@ import jsonLocales from '../locales.json';
 
 export const allLocales = jsonLocales;
 
-export default function resolveLocale(locale) {
+export default function resolveLocale(locale, localeObj = allLocales) {
   return function resolve(key) {
-    const locales = allLocales[locale];
-    
-      let localeStr = locales[key];
-    
-      if (typeof localeStr === 'undefined') {
-        localeStr = allLocales.en[key];
-      }
-    
-      return localeStr;
-  }
+    const locales = localeObj[locale];
+
+    let localeStr = locales[key];
+
+    if (typeof localeStr === 'undefined') {
+      localeStr = localeObj.en[key];
+    }
+
+    return localeStr;
+  };
 }

--- a/templates/index.js
+++ b/templates/index.js
@@ -8,12 +8,12 @@ import buildExtensionScripts from './utils/extensionScripts';
 
 const stylesheetTag = href => (href ? `<link rel="stylesheet" href="${href}" />` : '');
 
-export default ({ stylesheetLink, customCSS, currentUser, matchingUsers }) =>
+export default ({ stylesheetLink, customCSS, currentUser, matchingUsers, dynamicSettings }) =>
   new Promise((resolve) => {
     getStorage().read().then((data) => {
       const template = data.settings ? data.settings.template : defaultTemplate;
       
-      buildAuth0Widget().then((Auth0Widget) => {
+      buildAuth0Widget(dynamicSettings).then((Auth0Widget) => {
         resolve(render(template, {
           ExtensionCSS: stylesheetTag(stylesheetLink),
           CustomCSS: stylesheetTag(customCSS),

--- a/templates/utils/auth0widget.js
+++ b/templates/utils/auth0widget.js
@@ -1,7 +1,53 @@
 /* eslint-disable arrow-parens */
 import getCurrentLocale from '../../lib/locale';
-import svgDimensions from '../../lib/svgDimensions';
 import { getSettings } from '../../lib/storage';
+import svgDimensions from '../../lib/svgDimensions';
+import lockOverlay, { lockOutlineClass } from './lockOverlay';
+
+const getLogo = (settings) => {
+  if (settings.logoPath !== '') {
+    return `<img src='${settings.logoPath}' class="auth0-lock-header-logo" />`;
+  }
+
+  return `
+    <svg class="auth0-lock-header-logo" width="52.47px" height="58px" viewBox="0 0 151 172">
+        <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+            <g id="logo-grey-horizontal">
+                <g id="Group">
+                <g id="LogoBadge" fill-opacity="1" fill="rgb(234, 83, 35)">
+                    <path d="${svgDimensions.badge}" id="Shape"></path>
+                </g>
+                </g>
+            </g>
+        </g>
+    </svg>`;
+};
+
+const getTitle = (settings, t) => {
+  if (settings.title !== '') {
+    return settings.title;
+  }
+
+  return t('accountLinking');
+};
+
+const getSubmitButton = (settings, t) => {
+  let colorStyle = '';
+
+  if (settings.color !== '') {
+    colorStyle = `style="background-color: ${settings.color}"`;
+  }
+
+  return `
+    <button class="auth0-lock-submit" ${colorStyle} type="button" id="link">
+      <span class="auth0-label-submit">
+        <span id="label-value">${t('continue')}</span>
+        <span>
+          <svg class="icon-text" width="8px" height="12px" viewBox="0 0 8 12" version="1.1" xmlns="http://www.w3.org/2000/svg"><g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="Web/Submit/Active" transform="translate(-148.000000, -32.000000)" fill="#FFFFFF"><polygon id="Shape" points="148 33.4 149.4 32 155.4 38 149.4 44 148 42.6 152.6 38"></polygon></g></g></svg>
+        </span>
+      </span>
+    </button>`;
+};
 
 export default dynamicSettings =>
   new Promise(resolve => {
@@ -11,29 +57,8 @@ export default dynamicSettings =>
 
       resolve(`
             <div id="auth0-lock-container-1" class="auth0-lock-container">
-                <div class="auth0-lock auth0-lock-opened auth0-lock-with-tabs ${settings.removeOverlay ? 'auth0-lock-outlined' : ''}">
-                    ${settings.removeOverlay ? '' : `
-                        <div class="auth0-lock-overlay">
-                            <span class="auth0-lock-badge-bottom">
-                            <a href="https://auth0.com/?utm_source=lock&amp;utm_campaign=badge&amp;utm_medium=widget" target="_blank" class="auth0-lock-badge">
-                                <svg width="58px" height="21px" viewBox="0 0 462 168">
-                                <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                                    <g id="logo-grey-horizontal">
-                                    <g id="Group">
-                                        <g id="LogoText" transform="translate(188.000000, 41.500000)" fill="#D0D2D3">
-                                        <path d="${svgDimensions.text}" id="Shape"></path>
-                                        </g>
-                                        <g id="LogoBadge" fill-opacity="0.4" fill="#FFFFFF">
-                                        <path d="${svgDimensions.badge}" id="Shape"></path>
-                                        </g>
-                                    </g>
-                                    </g>
-                                </g>
-                                </svg>
-                            </a>
-                            </span>
-                        </div>
-                    `}
+                <div class="auth0-lock auth0-lock-opened auth0-lock-with-tabs ${lockOutlineClass(settings.removeOverlay)}">
+                    ${lockOverlay(settings.removeOverlay)}
                     <div class="auth0-lock-center">
                         <form class="auth0-lock-widget">
                         <div class="auth0-lock-widget-container">
@@ -44,26 +69,8 @@ export default dynamicSettings =>
                                 <div class="auth0-lock-header-bg-solid"></div>
                                 </div>
                                 <div class="auth0-lock-header-welcome">
-                                ${settings.logoPath !== ''
-    ? `
-
-                                <img src='${settings.logoPath}' class="auth0-lock-header-logo" />
-    ` : `
-
-                                <svg class="auth0-lock-header-logo" width="52.47px" height="58px" viewBox="0 0 151 172">
-                                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                                        <g id="logo-grey-horizontal">
-                                            <g id="Group">
-                                            <g id="LogoBadge" fill-opacity="1" fill="rgb(234, 83, 35)">
-                                                <path d="${svgDimensions.badge}" id="Shape"></path>
-                                            </g>
-                                            </g>
-                                        </g>
-                                    </g>
-                                </svg>
-
-                                `}
-                                <div class="auth0-lock-name">${settings.title !== '' ? settings.title : t('accountLinking')}</div>
+                                  ${getLogo(settings)}
+                                  <div class="auth0-lock-name">${getTitle(settings, t)}</div>
                                 </div>
                             </div>
                             <div id="error-message" class="auth0-global-message auth0-global-message-error"></div>
@@ -96,14 +103,7 @@ export default dynamicSettings =>
                                 </span>
                             </div>
                             <div class="auth0-lock-actions">
-                                <button class="auth0-lock-submit" ${settings.color !== '' ? `style="background-color: ${settings.color}"` : ''} type="button" id="link">
-                                <span class="auth0-label-submit">
-                                    <span id="label-value">${t('continue')}</span>
-                                    <span>
-                                    <svg class="icon-text" width="8px" height="12px" viewBox="0 0 8 12" version="1.1" xmlns="http://www.w3.org/2000/svg"><g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="Web/Submit/Active" transform="translate(-148.000000, -32.000000)" fill="#FFFFFF"><polygon id="Shape" points="148 33.4 149.4 32 155.4 38 149.4 44 148 42.6 152.6 38"></polygon></g></g></svg>
-                                    </span>
-                                </span>
-                                </button>
+                                ${getSubmitButton(settings, t)}
                             </div>
                             </div>
                         </div>

--- a/templates/utils/auth0widget.js
+++ b/templates/utils/auth0widget.js
@@ -3,16 +3,16 @@ import getCurrentLocale from '../../lib/locale';
 import svgDimensions from '../../lib/svgDimensions';
 import { getSettings } from '../../lib/storage';
 
-export default () =>
+export default dynamicSettings =>
   new Promise(resolve => {
-    getCurrentLocale().then(t => {
-      getSettings().then(settings => {
-        resolve(`
+    getSettings().then(storedSettings => {
+      const settings = Object.assign(storedSettings, dynamicSettings);
+      const t = getCurrentLocale(settings.locale);
+
+      resolve(`
             <div id="auth0-lock-container-1" class="auth0-lock-container">
                 <div class="auth0-lock auth0-lock-opened auth0-lock-with-tabs ${settings.removeOverlay ? 'auth0-lock-outlined' : ''}">
-                    ${settings.removeOverlay
-    ? ''
-    : `
+                    ${settings.removeOverlay ? '' : `
                         <div class="auth0-lock-overlay">
                             <span class="auth0-lock-badge-bottom">
                             <a href="https://auth0.com/?utm_source=lock&amp;utm_campaign=badge&amp;utm_medium=widget" target="_blank" class="auth0-lock-badge">
@@ -44,11 +44,11 @@ export default () =>
                                 <div class="auth0-lock-header-bg-solid"></div>
                                 </div>
                                 <div class="auth0-lock-header-welcome">
-                                ${settings.logoPath !== '' ? `
+                                ${settings.logoPath !== ''
+    ? `
 
                                 <img src='${settings.logoPath}' class="auth0-lock-header-logo" />
-                                
-                                ` : `
+    ` : `
 
                                 <svg class="auth0-lock-header-logo" width="52.47px" height="58px" viewBox="0 0 151 172">
                                     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -96,7 +96,7 @@ export default () =>
                                 </span>
                             </div>
                             <div class="auth0-lock-actions">
-                                <button class="auth0-lock-submit" ${settings.color !== '' ? `style="background-color: ${settings.color}"` : '' } type="button" id="link">
+                                <button class="auth0-lock-submit" ${settings.color !== '' ? `style="background-color: ${settings.color}"` : ''} type="button" id="link">
                                 <span class="auth0-label-submit">
                                     <span id="label-value">${t('continue')}</span>
                                     <span>
@@ -119,6 +119,5 @@ export default () =>
                 }
             </script>
             `);
-      });
     });
   });

--- a/templates/utils/lockOverlay.js
+++ b/templates/utils/lockOverlay.js
@@ -1,0 +1,31 @@
+import svgDimensions from '../../lib/svgDimensions';
+
+export const lockOutlineClass = (hide = false) => (hide ? 'auth0-lock-outlined' : '');
+
+export default function lockOverlay(hide = false) {
+  if (hide) {
+    return '';
+  }
+
+  return `
+    <div class="auth0-lock-overlay">
+        <span class="auth0-lock-badge-bottom">
+        <a href="https://auth0.com/?utm_source=lock&amp;utm_campaign=badge&amp;utm_medium=widget" target="_blank" class="auth0-lock-badge">
+            <svg width="58px" height="21px" viewBox="0 0 462 168">
+            <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g id="logo-grey-horizontal">
+                <g id="Group">
+                    <g id="LogoText" transform="translate(188.000000, 41.500000)" fill="#D0D2D3">
+                    <path d="${svgDimensions.text}" id="Shape"></path>
+                    </g>
+                    <g id="LogoBadge" fill-opacity="0.4" fill="#FFFFFF">
+                    <path d="${svgDimensions.badge}" id="Shape"></path>
+                    </g>
+                </g>
+                </g>
+            </g>
+            </svg>
+        </a>
+        </span>
+    </div>`;
+}

--- a/test/unit/locale_test.js
+++ b/test/unit/locale_test.js
@@ -1,0 +1,45 @@
+/* eslint-disable no-underscore-dangle */
+
+import { expect } from 'chai';
+import resolveLocale, { allLocales } from '../../lib/locale';
+
+const sampleLocales = {
+  en: {
+    _name: 'English',
+    a: 'en-a',
+    b: 'en-b',
+    c: 'en-c'
+  },
+  es: {
+    _name: 'Spanish',
+    a: 'es-a',
+    b: 'es-b'
+  }
+};
+
+describe('Locale tests', () => {
+  it('returns a function on initialization', () => {
+    const t = resolveLocale('en', sampleLocales);
+
+    expect(typeof t).to.equal('function');
+  });
+
+  it('returns the correct string', () => {
+    const t = resolveLocale('es', sampleLocales);
+
+    expect(t('a')).to.equal('es-a');
+  });
+
+  it('fallbacks to first locale if single string not found', () => {
+    const t = resolveLocale('es', sampleLocales);
+
+    expect(t('c')).to.equal('en-c');
+  });
+
+  it("each locale has a '_name' field", () => {
+    const locales = Object.keys(allLocales);
+    const localesWithName = locales.filter(l => allLocales[l]._name !== undefined);
+
+    expect(localesWithName.length).to.equal(locales.length);
+  });
+});


### PR DESCRIPTION
Allows the user to set dynamic settings by passing them through the querystring. (Example: Storezero and Storeone)

The *dynamic* settings will be merged with the stored/static ones, so you don't need to specify all fields.

Customizable settings:

Setting | Example
------------ | -------------
title      | `?title=Some%20Title`
color      | `?color=abc123`
logoPath   | `?logoPath=https%3A%2F%2Fcdn2.auth0.com%2Fwebsite%2Fplayground%2Fschneider.svg`
locale     | `?locale=es`