### PR TITLE
Fix stylesheet CDN URL (https:/)

### DIFF
--- a/lib/stylesheet.js
+++ b/lib/stylesheet.js
@@ -1,17 +1,16 @@
 const version = require('../package.json').version;
-const path = require('path');
 
 const CDN_BASE = `https://cdn.auth0.com/extensions/auth0-account-link-extension/${version}`;
-const LOCAL_BASE = `/css`;
+const LOCAL_BASE = '/css';
 
-const getBase = useCDN => useCDN ? CDN_BASE : LOCAL_BASE;
+const getBase = useCDN => (useCDN ? CDN_BASE : LOCAL_BASE);
 
 const generateHelper = (useCDN = false) => {
   const extension = useCDN ? 'min.css' : 'css';
   const link = (filename) => {
     const name = (filename || '').trim();
 
-    return name ? path.join(getBase(useCDN), `${name}.${extension}`) : '';
+    return name ? `${getBase(useCDN)}/${name}.${extension}` : '';
   };
 
   const tag = (filename) => {


### PR DESCRIPTION
for some reason: 
```js
return name ? path.join(getBase(true), `${name}.${extension}`) : ‘’;
```
 returns `https:/cdn.auth0.com/extensions/auth0-account-link-extension/2.0.0/link.css` (with one slash after https) so the styles were broken.