### PR TITLE
Apply required changes to migrate from blue Jenkins to core CI Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
 pipeline {
-    agent any
-    tools { nodejs 'node-v6.10.3' }
+    agent {
+        label 'crew-keystone'
+    }
+    tools { nodejs '6.10.3' }
     stages {
         stage('Checkout') {
           steps {
@@ -20,7 +22,7 @@ pipeline {
           }
         }
 
-        stage('Build') { 
+        stage('Build') {
             steps {
                 sh 'yarn run build'
             }


### PR DESCRIPTION
The blue jenkins instance will be deprecated, and all jobs are being migrated to
the core CI Jenkins instance at https://tools-jenkins-us-west-2.forge.auth0.net/
.  This makes the required changes to run compatibly on the this other instance.

After this is merged, I'll create the new jenkins job on https://tools-jenkins-us-west-2.forge.auth0.net/ .