### PR TITLE
Fixed about removing the period from the template and add it to locals.json

### DIFF
--- a/locales.json
+++ b/locales.json
@@ -8,7 +8,7 @@
       "It looks like you have another account with the same email address. We recommend you link these accounts.",
     "skipAlternativeLink": "I want to skip this and create a new account. (Not recommended)",
     "sameEmailAddressError": "Accounts must have matching email addresses. Please try again.",
-    "identities": "You may sign in with {{identities}} to link accounts",
+    "identities": "You may sign in with {{identities}} to link accounts.",
     "or": "or"
   },
 
@@ -23,7 +23,7 @@
     "skipAlternativeLink": "Quiero saltar esto y crear una nueva cuenta. (No recomendado)",
     "sameEmailAddressError":
       "Las cuentas deben tener la misma dirección de correo electrónico. Por favor intenta nuevamente.",
-    "identities": "Puedes iniciar sesión con {{identities}} para vincular las cuentas",
+    "identities": "Puedes iniciar sesión con {{identities}} para vincular las cuentas.",
     "or": "o"
   },
 

--- a/templates/utils/auth0widget.js
+++ b/templates/utils/auth0widget.js
@@ -87,7 +87,7 @@ module.exports = (dynamicSettings, identities, locale = 'en') =>
                                             <div class="auth0-lock-form" id="content-container">
                                                 <div>
                                                 <p id="message">
-                                                    ${t('introduction')} ${t('identities').replace(identitiesRegex, identities)}.
+                                                    ${t('introduction')} ${t('identities').replace(identitiesRegex, identities)}
                                                 </p>
                                                 <p class="auth0-lock-alternative">
                                                     <a class="auth0-lock-alternative-link" id="skip" href="#">


### PR DESCRIPTION
## ✏️ Changes
 
There is a minor issue for Japanese users.
The Japanese language uses '。' as a period.
However, the template itself has a period, so an unnecessarily additional period showed. (See the screenshot)

![accountlink](https://user-images.githubusercontent.com/331835/86258831-398b4980-bbf6-11ea-9ad1-d3ae35414496.JPG)

This change does not break any unit test.
  
## 🎯 Testing
  
> Describe how this can be tested by reviewers. Please be specific about anything not tested and reasons why.
> - Make sure you add unit and integration tests.
> - If this is on a hot path, add load or performance tests
> - Especially for dependency updates we also need to make sure that there is no impact on performance.
   
✅🚫 This change has been tested in a Webtask
 
✅🚫 This change has unit test coverage
  
✅🚫 This change has integration test coverage
  
✅🚫 This change has been tested for performance
  
## 🚀 Deployment
  
> Can this change be merged at any time? What will the deployment of the change look like? Does this need to be released in lockstep with something else?
  
✅ This can be deployed at any time
  
## 🎡 Rollout
  
> Explain how the change will be verified once released. Manual testing? Functional testing?
  
In order to verify that the deployment was successful we will do manual testing.

## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
