### PR TITLE
Add missing id provider mapping for AD

### DIFF
--- a/lib/idProviders.js
+++ b/lib/idProviders.js
@@ -1,5 +1,6 @@
 const providers = {
   auth0: 'Auth0',
+  ad: 'Active Directory',
   'google-oauth2': 'Google',
   facebook: 'Facebook',
   windowslive: 'Microsoft',


### PR DESCRIPTION
Add missing id provider mapping for AD / Active Directory

## ✏️ Changes
  
Mapping for AD was missing in id provider list, see screenshot.
  
## 📷 Screenshots

![Bildschirmfoto 2020-07-06 um 19 26 17](https://user-images.githubusercontent.com/295122/86745982-06541a80-c03b-11ea-98cf-76fc701ef0f0.png)

