### PR TITLE
fix: tweak to always link the new accounts to the first one

### DIFF
--- a/api/get_index.js
+++ b/api/get_index.js
@@ -22,7 +22,7 @@ const decodeToken = token =>
 const fetchUsersFromToken = ({ sub, email }) =>
   findUsersByEmail(email).then(users => ({
     currentUser: users.find(u => u.user_id === sub),
-    matchingUsers: users.filter(u => u.user_id !== sub)
+    matchingUsers: users.filter(u => u.user_id !== sub).sort((prev, next) => new Date(prev.created_at) - new Date(next.created_at))
   }));
 
 module.exports = () => ({

--- a/api/get_index.js
+++ b/api/get_index.js
@@ -22,7 +22,9 @@ const decodeToken = token =>
 const fetchUsersFromToken = ({ sub, email }) =>
   findUsersByEmail(email).then(users => ({
     currentUser: users.find(u => u.user_id === sub),
-    matchingUsers: users.filter(u => u.user_id !== sub).sort((prev, next) => new Date(prev.created_at) - new Date(next.created_at))
+    matchingUsers: users
+      .filter(u => u.user_id !== sub)
+      .sort((prev, next) => new Date(prev.created_at) - new Date(next.created_at))
   }));
 
 module.exports = () => ({


### PR DESCRIPTION
## ✏️ Changes
  
When trying to link the 2nd or the 3rd account, it doesn't link to the 1st account.
Example:

> - When tries to linking the 2nd account, it linking the 3rd account.
> - When tries to linking the 3rd account, it linking the 2nd account.

It makes much more sense to always linking to the 1st account.