### PR TITLE
[ESD-8265] fix introduction text when user has multiple identities

### DIFF
--- a/api/get_index.js
+++ b/api/get_index.js
@@ -54,10 +54,17 @@ module.exports = () => ({
         fetchUsersFromToken(token)
           .then(({ currentUser, matchingUsers }) => {
             getSettings().then((settings) => {
+              // if there are multiple matching users, take the oldest one
               const userMetadata = (matchingUsers[0] && matchingUsers[0].user_metadata) || {};
               const locale = userMetadata.locale || settings.locale;
               resolveLocale(locale).then((t) => {
-                const rawIdentities = matchingUsers.length > 0 ? matchingUsers[0].identities : [];
+                // FIXME: The "continue" button is always poiting to first user's identity
+                // connection, so we can't show all available alternatives in the introduction
+                // text: "You may sign in with IdP1 or IdP2 or..."
+                // A proper fix could be showing multiple "continue" links (one per existing
+                // identity) or one "continue" link with a connection selector.
+                const rawIdentities =
+                  matchingUsers.length > 0 ? [matchingUsers[0].identities[0]] : [];
                 const identities = rawIdentities
                   .map(id => id.provider)
                   .map(getIdentityProviderPublicName);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-account-link-extension",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Auth0 Account Link Extension",
   "main": "index.js",
   "engines": {

--- a/webtask.json
+++ b/webtask.json
@@ -1,8 +1,8 @@
 {
   "title": "Auth0 Account Link",
   "name": "auth0-account-link",
-  "version": "2.5.0",
-  "preVersion": "2.4.0",
+  "version": "2.6.0",
+  "preVersion": "2.5.0",
   "author": "auth0",
   "description":
     "This extension gives Auth0 customers the ability to allow their users to link their accounts",


### PR DESCRIPTION
## ✏️ Changes
  
Reported by https://github.com/auth0-extensions/auth0-account-link-extension/issues/56

![image](https://user-images.githubusercontent.com/178506/91108714-1e194980-e64f-11ea-8e88-b3cb94c566e2.png)

This is a quick fix to avoid confusion when user has multiple identities.
A proper fix could be to allow to select the identity before proceed.