### PR TITLE
[ESD-8609] avoid unhandled error when user locale is invalid/unsupported

### DIFF
--- a/api/get_index.js
+++ b/api/get_index.js
@@ -56,7 +56,7 @@ module.exports = () => ({
             getSettings().then((settings) => {
               // if there are multiple matching users, take the oldest one
               const userMetadata = (matchingUsers[0] && matchingUsers[0].user_metadata) || {};
-              const locale = userMetadata.locale || settings.locale;
+              const locale = typeof userMetadata.locale === 'string' ? userMetadata.locale : settings.locale;
               resolveLocale(locale).then((t) => {
                 // FIXME: The "continue" button is always poiting to first user's identity
                 // connection, so we can't show all available alternatives in the introduction

--- a/lib/locale.js
+++ b/lib/locale.js
@@ -7,7 +7,7 @@ const missingLocaleStr = '(MISSING_LOCALE)';
 
 function resolveLocale(locale = 'en', overrideLocales) {
   const returnableFunction = localeObj => (key) => {
-    const locales = localeObj[locale];
+    const locales = localeObj[locale] || {};
 
     const localeStr = locales[key];
 


### PR DESCRIPTION
* Extension is resolving locale based on `user.user_metadata.locale` attribute: https://github.com/auth0-extensions/auth0-account-link-extension/blob/45ff92bc53fadf0e670ee92ec429fe744168d939/api/get_index.js#L59-L60
* But, when `user_metadata` has an invalid/unsupported locale, the extension isn’t handling it in a proper way, causing an unhandled rejection: https://github.com/auth0-extensions/auth0-account-link-extension/blob/45ff92bc53fadf0e670ee92ec429fe744168d939/lib/locale.js#L8-L12

More context: https://auth0team.atlassian.net/jira/servicedesk/projects/ESD/queues/custom/313/ESD-8609