### PR TITLE
Add Brazilian portuguese translation + fix Japanese typo

### DIFF
--- a/locales.json
+++ b/locales.json
@@ -38,5 +38,18 @@
     "sameEmailAddressError": "一致するメールアドレスが見つかりませんでした。もう一度ログインしてください。",
     "identities": "統合すると{{identities}}でログインできるようになります。",
     "or": "または"
+  },
+
+  "pt-BR": {
+    "_name": "Brazilian Portuguese",
+    "pageMismatchError": "Parece que você chegou a essa página devido a um erro. Tente realizar o login novamente",
+    "continue": "Continuar",
+    "accountLinking": "Vinculação de contas",
+    "introduction":
+      "Aparentemente você possui uma outra conta com esse endereço de email. Nós recomendamos que você vincule essas contas.",
+    "skipAlternativeLink": "Desejo pular essa etapa e criar uma nova conta. (Não recomendado)",
+    "sameEmailAddressError": "As contas devem possuir o mesmo endereço de email. Favor tentar novamente.",
+    "identities": "Você pode realizar o login com {{identities}} para vincular as contas",
+    "or": "ou"
   }
 }

--- a/locales.json
+++ b/locales.json
@@ -28,7 +28,7 @@
   },
 
   "ja": {
-    "_name": "Japanease",
+    "_name": "Japanese",
     "pageMismatchError": "アクセスに失敗しました。もう一度ログインしてください。",
     "continue": "続ける",
     "accountLinking": "アカウントリンク",


### PR DESCRIPTION
## ✏️ Changes
  
Currently, Brazilian portuguese is not supported by the Account Linking Extension. This PR adds Brazilian Portuguese support. Moreover, this PR fixes a typo in the Japanese name on the locales file.  
## 📷 Screenshots

  
## 🔗 References
  
## 🎯 Testing
   
✅🚫 This change has been tested in a Webtask
 
✅🚫 This change has unit test coverage
  
✅🚫 This change has integration test coverage
  
✅🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅🚫 This can be deployed any time
  
## 🎡 Rollout
  
## 🔥 Rollback
  
### 📄 Procedure
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
