### PR TITLE
Account Linking Extension not using custom CSS when specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ yarn run build
 Bundle file (`auth0-account-link.extension.VERSION.js` is found in `/dist`
 Asset CSS files are found in `/dist/assets`
 
-Before continuing, if you want to quickly test backend-only changes in your production tenant, you can use the webtask editor: https://github.com/auth0-extensions/auth0-webtask-editor-opener. Copy and paste the bundle file file contents into the tab that corresponds with the existing extension to override the backend code. 
+Before continuing, if you want to quickly test backend-only changes in your production tenant, follow https://auth0team.atlassian.net/wiki/spaces/USER/pages/1931838732/Testing+Dev+Build+of+Extension+with+Production+tenant
 
 Follow the instructions in the deployment tool.  This tool will also automatically generate a PR in the `auth0-extensions` repo.  Only after the PR is merged will the extension be available in production.  Before merging the PR you can use this tool to test the upgrade: https://github.com/auth0-extensions/auth0-extension-update-tester by overriding the `extensions.json` file that is fetched by the dashboard.  You will need to clone this repo: https://github.com/auth0/auth0-extensions, update `extensions.json` locally and then run `npx http-server --port 3000 --cors` to serve up the file.  Then configure the extension with `http://localhost:3000/extensions.json` as the path.

--- a/api/get_index.js
+++ b/api/get_index.js
@@ -40,7 +40,7 @@ module.exports = () => ({
     }
     const stylesheetHelper = stylesheet(config('NODE_ENV') === 'production');
     const stylesheetTag = stylesheetHelper.tag('link');
-    const customCSSTag = stylesheetHelper.tag(config('CUSTOM_CSS'));
+    const customCSSTag = stylesheetHelper.tag(config('CUSTOM_CSS'), true);
     const params = req.query;
 
     const dynamicSettings = {};

--- a/lib/stylesheet.js
+++ b/lib/stylesheet.js
@@ -7,14 +7,14 @@ const getBase = useCDN => (useCDN ? CDN_BASE : LOCAL_BASE);
 
 const generateHelper = (useCDN = false) => {
   const extension = useCDN ? `${version}.min.css` : 'css';
-  const link = (filename) => {
+  const link = (filename, isAbsolute) => {
     const name = (filename || '').trim();
-
+    if (isAbsolute) return name;
     return name ? `${getBase(useCDN)}/${name}.${extension}` : '';
   };
 
-  const tag = (filename) => {
-    const href = link(filename);
+  const tag = (name, isAbsolute = false) => {
+    const href = link(name, isAbsolute);
 
     return href ? `<link rel="stylesheet" href="${href}">` : '';
   };

--- a/test/unit/stylesheet_test.js
+++ b/test/unit/stylesheet_test.js
@@ -23,6 +23,13 @@ describe('Stylesheet helper', () => {
     expect(result).to.be.empty;
   });
 
+  it('with absolute URL', () => {
+    const { tag } = stylesheet();
+    const result = tag('htps://custom.css', true);
+
+    expect(result).to.equal('htps://custom.css');
+  });
+
   describe('When using cdn', () => {
     const { tag } = stylesheet(true);
 
@@ -36,6 +43,12 @@ describe('Stylesheet helper', () => {
       const result = tag('test');
 
       expect(result).to.match(/\/test\.\d+\.\d+\.\d+\.min\.css/);
+    });
+
+    it('with absolute URL', () => {
+      const result = tag('htps://custom.css', true);
+
+      expect(result).to.equal('htps://custom.css');
     });
   });
 });


### PR DESCRIPTION
## ✏️ Changes
  
Changes to apply custom CSS in account link extension. Consider custom css link as absolute URL, no need to prefix it with CDN base.
  
## 📷 Screenshots

Change CSS:

![image](https://user-images.githubusercontent.com/15273690/112693945-7c114800-8e4f-11eb-8e6e-90853ac190b3.png)
 
Before fix:

![image](https://user-images.githubusercontent.com/15273690/112693957-816e9280-8e4f-11eb-9ae3-0c9ed845c86c.png)

After fix: (Notice lower cased "Continue" button , it was lower cased in custom CSS)
![image](https://user-images.githubusercontent.com/15273690/112693975-8895a080-8e4f-11eb-9c93-f66cf3cec022.png)

  
  
## 🎯 Testing
  

✅This change has been tested in a Webtask
 
✅This change has unit test coverage
  

## 🚀 Deployment
  

  
✅This can be deployed any time
  

## 🎡 Rollout
  
Manual testing
  

## 🔥 Rollback
  
Revert commit and release again
  
 
## 🖥 Appliance
  
It is compatible