### PR TITLE
Adds waad, fixes fallback

### DIFF
--- a/lib/idProviders.js
+++ b/lib/idProviders.js
@@ -41,11 +41,12 @@ const providers = {
   exact: 'Exact.com',
   daccount: 'NTT Docomo',
   sms: 'SMS Code',
+  waad: 'Azure AD',
   email: 'E-mail Code'
 };
 
 module.exports = function getIdentityProviderPublicName(slug) {
   const provider = providers[slug];
 
-  return typeof provider !== 'undefined' ? provider : slug;
+  return typeof provider !== undefined ? provider : slug;
 };


### PR DESCRIPTION
Adds `waad` as a known connection type, and fixes the fallback case when the connection type was not previously mapped, to use the connection type as a description.

This is the UI you currently get if you had `waad` or another unmapped connection type:

![image](https://user-images.githubusercontent.com/5222181/125126683-50d60000-e0b0-11eb-9eb0-a26a5b17ec47.png)

  
## 🔗 References

Reported in support case #00492207.

## 🎯 Testing

1. Install the extension
2. Log in with an Azure AD connection
3. Then log in with another provider using the same email address.
4. The extension should prompt you to log in with Azure AD

   
🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
> Can this change be merged at any time? What will the deployment of the change look like? Does this need to be released in lockstep with something else?
  
✅ This can be deployed any time
  
