### PR TITLE
Fix duplicate period

### DIFF
--- a/locales.json
+++ b/locales.json
@@ -8,7 +8,7 @@
       "It looks like you have another account with the same email address. We recommend you link these accounts.",
     "skipAlternativeLink": "I want to skip this and create a new account. (Not recommended)",
     "sameEmailAddressError": "Accounts must have matching email addresses. Please try again.",
-    "identities": "You may sign in with {{identities}} to link accounts",
+    "identities": "You may sign in with {{identities}} to link accounts.",
     "or": "or"
   },
 
@@ -23,7 +23,7 @@
     "skipAlternativeLink": "Quiero saltar esto y crear una nueva cuenta. (No recomendado)",
     "sameEmailAddressError":
       "Las cuentas deben tener la misma dirección de correo electrónico. Por favor intenta nuevamente.",
-    "identities": "Puedes iniciar sesión con {{identities}} para vincular las cuentas",
+    "identities": "Puedes iniciar sesión con {{identities}} para vincular las cuentas.",
     "or": "o"
   },
 

--- a/templates/utils/auth0widget.js
+++ b/templates/utils/auth0widget.js
@@ -87,7 +87,7 @@ module.exports = (dynamicSettings, identities, locale = 'en') =>
                                             <div class="auth0-lock-form" id="content-container">
                                                 <div>
                                                 <p id="message">
-                                                    ${t('introduction')} ${t('identities').replace(identitiesRegex, identities)}.
+                                                    ${t('introduction')} ${t('identities').replace(identitiesRegex, identities)}
                                                 </p>
                                                 <p class="auth0-lock-alternative">
                                                     <a class="auth0-lock-alternative-link" id="skip" href="#">


### PR DESCRIPTION
Thank you for developing such an awesome product!
I noticed a small problem and tried to fix it. Please review :)

## ✏️ Changes
If we select a Japanese locale for the Account Link UI, the actual message is a bit weird...
`。` means a period in Japanese, and currently, `identities` in `ja` locale has `。` and the others don't have a period (`.`) in the sentence.

Seeing the `identities` part in the actual view, it includes `.`, so if we use Japanese, there are two periods in the constructed message (like `...ログインできるようになります。.`).

This PR adjusts the locales and the template so that all locales work fine! 
  
## 📷 Screenshots
 
If there were visual changes to the application with this change, please include before and after screenshots here. If it has animation, please use screen capture software like  to make a gif.
  
## 🔗 References
  
## 🎯 Testing
  
✅🚫 This change has been tested in a Webtask
 
✅🚫 This change has unit test coverage
  
✅🚫 This change has integration test coverage
  
✅🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅🚫 This can be deployed any time
  
## 🎡 Rollout
  
  
## 🔥 Rollback
 
  
### 📄 Procedure
 
## 🖥 Appliance

