### PR TITLE
Use /api/v2/users to find matching emails

### DIFF
--- a/lib/findUsersByEmail.js
+++ b/lib/findUsersByEmail.js
@@ -2,8 +2,10 @@ const apiCall = require('./api');
 
 const findUsersByEmail = email =>
   apiCall({
-    path: 'users-by-email',
-    qs: { email }
+    path: 'users',
+    qs: {
+      q: `email:"${email}"`
+    }
   });
 
 module.exports = findUsersByEmail;

--- a/rules/link.js
+++ b/rules/link.js
@@ -22,8 +22,7 @@ module.exports = ({ extensionURL = '', username = 'Unknown', clientID = '', clie
   var config = {
     endpoints: {
       linking: '${extensionURL.replace(/\/$/g, '')}',
-      userApi: auth0.baseUrl + '/users',
-      usersByEmailApi: auth0.baseUrl + '/users-by-email'
+      userApi: auth0.baseUrl + '/users'
     },
     token: {
       clientId: '${clientID}',
@@ -201,9 +200,9 @@ module.exports = ({ extensionURL = '', username = 'Unknown', clientID = '', clie
 
   function searchUsersWithSameEmail() {
     return apiCall({
-      url: config.endpoints.usersByEmailApi,
+      url: config.endpoints.userApi,
       qs: {
-        email: user.email
+        q: 'email:"' + user.email + '"'
       }
     });
   }


### PR DESCRIPTION
Switches back to GET /api/v2/users to find matching email addresses so that the search is case-insensitive.

## ✏️ Changes
  
Currently, the extension (both in the rules and in the back end) searches for identities with the same email address with the `GET /api/v2/users-by-email` endpoint. While this endpoint is very efficient, the search it performs is case sensitive. This is a problem for some enterprise identity providers that provide the email address in a capitalized form (e.g. `John.Doe@acme.com` instead of `john.doe@acme.com`). 
With PR switches to the `GET /api/v2/users` endpoint, with a `q=email:john.doe@acme.com` like query string. This search is case insensitive, allowing matches where the casing is different. The search needs to be changed in two pieces:

- In the rule, where matching identities are searched for during the first login
- In the backend, where matching identities are searched to present the option to the user

The slight performance hit from not using `/users-by-email` should be negligent, since the search is only done on the first login of an identity.

## 🔗 References
  
IUM-1301
  
## 🎯 Testing
  
🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
   
✅ This can be deployed any time
  
## 🎡 Rollout
  
## 🔥 Rollback
   
### 📄 Procedure
   
## 🖥 Appliance
  
