### PR TITLE
Update put_settings.js to allow longer tld's to be used

### DIFF
--- a/api/admin/put_settings.js
+++ b/api/admin/put_settings.js
@@ -3,7 +3,7 @@
 const Joi = require('joi');
 const { setSettings } = require('../../lib/storage');
 
-const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
+const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,24}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
 const colorRegex = /^#[A-Fa-f0-9]{6}/;
 
 module.exports = () => ({


### PR DESCRIPTION
## ✏️ Changes
 
Description:

-> The current longest tld is 24 characters as of (https://data.iana.org/TLD/tlds-alpha-by-domain.txt) so the max length should be increased from 6 to 24 to allow all domains to be used

What did you change in the code itself?

-> Increased a value in the RegEx to allow longer tlds to be used.

## 🔗 References
  
List of official TLD's that should be supported:
https://data.iana.org/TLD/tlds-alpha-by-domain.txt
  
## 🎯 Testing
  
> Describe how this can be tested by reviewers. Please be specific about anything not tested and reasons why.

Try the RegEx with a domain that has a longer tld than 6 characters

## 🚀 Deployment
  
> Can this change be merged at any time? What will the deployment of the change look like? Does this need to be released in lockstep with something else?
  
✅ This can be deployed any time
  
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
