### PR TITLE
fix: ensure test workflow runs on PRs from forked branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,8 @@
 name: Test
 
 on:
-  push:
-    branches-ignore: [ master ]
+  pull_request:
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   test:

--- a/test/acceptance/endpoints_test.js
+++ b/test/acceptance/endpoints_test.js
@@ -174,7 +174,9 @@ describe('Endpoint tests', function() {
             { code: 'es', name: 'Spanish' },
             { code: 'ja', name: 'Japanease' },
             { code: 'fr', name: 'French' },
-            { code: 'nl', name: 'Dutch' }
+            { code: 'nl', name: 'Dutch' },
+            { code: 'sv', name: 'Swedish' },
+            { code: 'pl', name: 'Polish' },
           ]
         })
       });
@@ -361,7 +363,9 @@ describe('Endpoint tests', function() {
             { code: 'es', name: 'Spanish' },
             { code: 'ja', name: 'Japanease' },
             { code: 'fr', name: 'French' },
-            { code: 'nl', name: 'Dutch' }
+            { code: 'nl', name: 'Dutch' },
+            { code: 'sv', name: 'Swedish' },
+            { code: 'pl', name: 'Polish' },
           ]
         })
       });


### PR DESCRIPTION
## ✏️ Changes

This PR fixes several broken tests, and ensures that the test workflow runs on PRs from forked branches. The tests were not run on https://github.com/auth0-extensions/auth0-account-link-extension/pull/189 and several of them were broken.