### PR TITLE
chore: allow publishing beta releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   AWS_ROLE: ${{ secrets.awsIAMS3UploadRole }}
+  AWS_ROLE_BETA: ${{ secrets.awsIAMS3UploadBetaRole }}
 
 jobs:
   pre-flight:
@@ -56,11 +57,20 @@ jobs:
       - name: Run Build
         run: yarn run build
 
-      - name: Configure AWS Credentials using OIDC
+      - name: Configure AWS Credentials (beta) using OIDC
+        if: needs.pre-flight.outputs.should_publish_beta == 'true'
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4 on 2025-01-06
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_BETA }}
+          role-session-name: github-action-account-link-extension-publish-beta
+          aws-region: us-west-1
+
+      - name: Configure AWS Credentials (prod) using OIDC
+        if: needs.pre-flight.outputs.should_publish_prod == 'true'
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4 on 2025-01-06
         with:
           role-to-assume: ${{ env.AWS_ROLE }}
-          role-session-name: github-action-account-link-extension-publish
+          role-session-name: github-action-account-link-extension-publish-prod
           aws-region: us-west-1
 
       - name: Run Deploy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,12 @@ name: Build
 on:
   push:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Optional note for manual run"
+        required: false
+        type: string
 
 permissions:
   id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
-  workflow_dispatch:
-    inputs:
-      reason:
-        description: "Optional note for manual run"
-        required: false
-        type: string
+    branches: [master]
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   id-token: write
@@ -18,7 +14,27 @@ env:
   AWS_ROLE: ${{ secrets.awsIAMS3UploadRole }}
 
 jobs:
+  pre-flight:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish_beta: ${{ steps.check.outputs.beta }}
+      should_publish_prod: ${{ steps.check.outputs.prod }}
+
+    steps:
+      - name: Check conditions
+        id: check
+        run: |
+          # Evaluate the logic directly and assign to shell variables
+          beta_condition=${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(toJson(github.event.pull_request.labels), 'publish-beta') }}
+          prod_condition=${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+
+          # Set the outputs for other jobs to use
+          echo "beta=$beta_condition" >> $GITHUB_OUTPUT
+          echo "prod=$prod_condition" >> $GITHUB_OUTPUT
+
   build-and-deploy:
+    needs: pre-flight
+    if: needs.pre-flight.outputs.should_publish_beta == 'true' || needs.pre-flight.outputs.should_publish_prod == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +43,12 @@ jobs:
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: '22'
+          node-version: "22"
+
+      - name: Inject beta version (internal PRs labeled publish-beta)
+        if: needs.pre-flight.outputs.should_publish_beta == 'true'
+        # Pass monotonically increasing GitHub run number to ensure unique beta artifacts.
+        run: node tools/beta-version.js ${{ github.run_number }}
 
       - name: Install dependencies
         run: yarn

--- a/README.md
+++ b/README.md
@@ -51,25 +51,28 @@ yarn test
 
 ## Release Process
 
-Deployment is now handled by the GitHub Actions workflow (`.github/workflows/build.yml`). It runs automatically on:
+Deployment is handled by the GitHub Actions workflow (`.github/workflows/build.yml`). It runs automatically on:
 
-1. Push/merge to `master` (stable releases)
-2. Manual trigger ("Run workflow" in the GitHub UI) against any branch (useful for beta / pre‑release testing)
+1. Push/merge to `master` (stable release → prod CDN path `/extensions`)
+2. Any pull request activity (open/update/reopen/labeled) that has the `publish-beta` label (beta pre-release → beta CDN path `/extensions/develop`)
 
-### 1. Bump the Version
-Update the version in BOTH `package.json` and `webtask.json`.
+### 1. Versioning
+Stable releases: manually bump the semantic version in BOTH `package.json` and `webtask.json` on a branch that will merge to `master` (e.g. set to `3.5.0`).
 
-Use semantic versions. Append `-beta.N` for beta builds, e.g. `3.5.0-beta.1`.
+Beta releases: DO NOT add a `-beta` suffix yourself. Label the PR with `publish-beta`. During the workflow the versions in `package.json` and `webtask.json` are rewritten (in the workspace of the build only) to:
+
+```
+<baseVersion>-beta.<RUN_NUMBER>
+```
+
+`<RUN_NUMBER>` is the monotonically increasing GitHub workflow run number, ensuring every beta publish produces a unique, non-overwritten artifact. Example: base `3.5.0` + run `451` → `3.5.0-beta.451`.
 
 ### 2. Open a PR
-Commit the version bump + any changes. When the PR merges to `master`, the workflow will build and publish automatically.
+Commit the stable version bump + changes. When the PR merges to `master`, a stable publish occurs.
 
-For a beta: work on any branch and ensure the version string itself includes `beta`.
+For a beta: open a PR from any internal branch, apply the `publish-beta` label. Each workflow run (new commit or relabel) generates a fresh `<base>-beta.<RUN_NUMBER>` version. Older beta versions remain in the CDN; only the major.minor alias (e.g. `3.5`) is overwritten.
 
-### 3. (Optional) Manual Run
-If you need to publish without merging yet, open the Actions tab, select the Build workflow, click "Run workflow", choose the branch, optionally include a note, and run it.
-
-### 4. Build Locally (if you want to verify before pushing)
+### 3. Build Locally (if you want to verify before pushing)
 ```bash
 nvm use 22
 yarn install
@@ -80,18 +83,19 @@ Artifacts produced:
 - Bundle file (`auth0-account-link.extension.VERSION.js`) is found in `/dist`
 - Asset CSS files are found in `/dist/assets`
 
-### 5. Publication Targets
+### 4. Publication Targets
 The workflow/script (`tools/cdn.sh`) uploads to S3:
 - Stable (no `beta` in version): `s3://assets.us.auth0.com/extensions/auth0-account-link/`
 - Beta (version contains `beta`): `s3://assets.us.auth0.com/extensions/develop/auth0-account-link/`
 
-We publish both an full version (eg: `1.2.3`), and a major.minor version (eg: `1.2`). The major.minor version will be overwritten on each publish, while the full version will NOT be overwritten. 
+We publish both a full version (eg: `1.2.3`), and a major.minor version (eg: `1.2`). The major.minor version will be overwritten on each publish, while the full version will NOT be overwritten. 
 
-### 6. Caching & Re-Publishing
-Increment the version to force a new publish.
+### 5. Caching & Re-Publishing
+Stable: increment the version (e.g. `3.5.1`) to publish a new immutable full version plus updated major.minor alias.
+Beta: every run already creates a unique `<base>-beta.<RUN_NUMBER>`; no manual increment needed unless you change the base version.
 
-### 7. Testing a Beta or Candidate
+### 6. Testing a Beta or Candidate
 Because beta assets are isolated under `extensions/develop`, production consumers will not pick them up automatically.
 
-### 8. Promoting to Stable
-Once validated, remove the `-beta.*` suffix, bump to the final version (e.g. `3.5.0`), merge to `master` (or manually trigger on the release commit), and a stable publish will occur.
+### 7. Promoting to Stable
+Remove the `publish-beta` label, ensure `package.json` & `webtask.json` have the desired final version without any beta suffix (e.g. `3.5.0`), merge to `master`. A stable publish with immutable full version + refreshed major.minor alias occurs.

--- a/README.md
+++ b/README.md
@@ -51,20 +51,47 @@ yarn test
 
 ## Release Process
 
-Deployment is currently done using this tool: https://auth0-extensions.us.webtask.io/extensions-deploy
+Deployment is now handled by the GitHub Actions workflow (`.github/workflows/build.yml`). It runs automatically on:
 
-First bump the version in `package.json` and in `webtask.json`
+1. Push/merge to `master` (stable releases)
+2. Manual trigger ("Run workflow" in the GitHub UI) against any branch (useful for beta / pre‑release testing)
 
-Then build the extension:
+### 1. Bump the Version
+Update the version in BOTH `package.json` and `webtask.json`.
 
+Use semantic versions. Append `-beta.N` for beta builds, e.g. `3.5.0-beta.1`.
+
+### 2. Open a PR
+Commit the version bump + any changes. When the PR merges to `master`, the workflow will build and publish automatically.
+
+For a beta: work on any branch and ensure the version string itself includes `beta`.
+
+### 3. (Optional) Manual Run
+If you need to publish without merging yet, open the Actions tab, select the Build workflow, click "Run workflow", choose the branch, optionally include a note, and run it.
+
+### 4. Build Locally (if you want to verify before pushing)
 ```bash
-nvm use 10
+nvm use 22
 yarn install
 yarn run build
 ```
 
-Bundle file (`auth0-account-link.extension.VERSION.js` is found in `/dist`
-Asset CSS files are found in `/dist/assets`
+Artifacts produced:
+- Bundle file (`auth0-account-link.extension.VERSION.js`) is found in `/dist`
+- Asset CSS files are found in `/dist/assets`
 
-Follow the instructions in the deployment tool.  This tool will also automatically generate a PR in the `auth0-extensions` repo.  Only after the PR is merged will the extension be available in production.  Before merging the PR you can use this tool to test the upgrade: https://github.com/auth0-extensions/auth0-extension-update-tester by overriding the `extensions.json` file that is fetched by the dashboard.  You will need to clone this repo: https://github.com/auth0/auth0-extensions, update `extensions.json` locally and then run `npx http-server --port 3000 --cors` to serve up the file.  Then configure the extension with `http://localhost:3000/extensions.json` as the path.
+### 5. Publication Targets
+The workflow/script (`tools/cdn.sh`) uploads to S3:
+- Stable (no `beta` in version): `s3://assets.us.auth0.com/extensions/auth0-account-link/`
+- Beta (version contains `beta`): `s3://assets.us.auth0.com/extensions/develop/auth0-account-link/`
 
+We publish both an full version (eg: `1.2.3`), and a major.minor version (eg: `1.2`). The major.minor version will be overwritten on each publish, while the full version will NOT be overwritten. 
+
+### 6. Caching & Re-Publishing
+Increment the version to force a new publish.
+
+### 7. Testing a Beta or Candidate
+Because beta assets are isolated under `extensions/develop`, production consumers will not pick them up automatically.
+
+### 8. Promoting to Stable
+Once validated, remove the `-beta.*` suffix, bump to the final version (e.g. `3.5.0`), merge to `master` (or manually trigger on the release commit), and a stable publish will occur.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "serve:dev": "gulp run",
-    "client:build": "minify --clean --output dist/assets/link.$npm_package_version.min.css public/css/link.css && minify --clean --output dist/assets/admin.$npm_package_version.min.css public/css/admin.css",
+    "client:build": "minify --clean --output dist/assets/link.$npm_package_version.min.css public/css/link.css && minify --clean --output dist/assets/admin.$npm_package_version.min.css public/css/admin.css && MAJORMINOR=$(node tools/attribute.js version ../package.json majorminor) && cp dist/assets/link.$npm_package_version.min.css dist/assets/link.$MAJORMINOR.min.css && cp dist/assets/admin.$npm_package_version.min.css dist/assets/admin.$MAJORMINOR.min.css",
     "extension:build": "a0-ext build:server ./webtask.js ./dist && cp ./dist/auth0-account-link-extension.extension.$npm_package_version.js ./build/bundle.js",
     "build": "yarn run client:build && yarn run extension:build"
   },

--- a/tools/beta-version.js
+++ b/tools/beta-version.js
@@ -1,0 +1,47 @@
+/*
+ * Automatically adjust package.json and webtask.json versions for beta publishes.
+ * Triggered only in pull_request context when the PR has the 'publish-beta' label.
+ *
+ * Rules:
+ *  - Reads current package.json version (e.g., 3.1.0).
+ *  - Produces a beta version: <MAJOR>.<MINOR>.<PATCH>-beta.<SEQ>
+ *    where <SEQ> is an incrementing number (GITHUB_RUN_NUMBER) so each run
+ *    creates a unique beta artifact without overwriting previous ones.
+ *    (If patch already contains -beta, it's replaced.)
+ *  - Writes back to package.json and webtask.json.
+ *  - Echoes the new version so subsequent steps (build, cdn.sh) use it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function computeBeta(baseVersion, sequence) {
+  // Strip existing beta suffix if present.
+  const core = baseVersion.split('-')[0];
+  return `${core}-beta.${sequence}`;
+}
+
+function updateFile(filePath, newVersion) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  const json = JSON.parse(src);
+  json.version = newVersion;
+  fs.writeFileSync(filePath, JSON.stringify(json, null, 2) + '\n');
+}
+
+function run() {
+  // Sequence number is provided as first CLI argument. Fallback to '0' if missing.
+  const sequence = process.argv[2] || '0';
+  const pkgPath = path.join(__dirname, '..', 'package.json');
+  const webtaskPath = path.join(__dirname, '..', 'webtask.json');
+
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const baseVersion = pkg.version;
+  const betaVersion = computeBeta(baseVersion, sequence);
+
+  updateFile(pkgPath, betaVersion);
+  updateFile(webtaskPath, betaVersion);
+
+  console.log(`Beta version injected (sequence ${sequence}): ${betaVersion}`);
+}
+
+run();

--- a/tools/cdn.sh
+++ b/tools/cdn.sh
@@ -1,36 +1,50 @@
-
 CURRENT_VERSION=$(node tools/attribute.js version)
 MAJORMINOR_VERSION_ONLY=$(node tools/attribute.js version ../package.json majorminor)
 EXTENSION_NAME="auth0-account-link"
 
+# Check if the current version is a beta version. If so, we'll
+# deploy to extensions/develop, rather than `extensions`.
+IS_BETA=$(echo "$CURRENT_VERSION" | grep -c "beta")
+
+# Determine base path depending on beta flag.
+if [ "$IS_BETA" -eq 1 ]; then
+  EXTENSIONS_PATH="extensions/develop"
+  echo "Beta version detected ($CURRENT_VERSION). Using 'develop' CDN path."
+else
+  EXTENSIONS_PATH="extensions"
+fi
+
 deploy_bundle() {
+  # Arguments:
+  #  $1 -> version string to publish (full or major.minor alias)
+
   if [ -z "$1" ]; then
     echo "No version provided. Skipping cdn publish…"
     exit 1
   fi
 
-  BUNDLE_EXISTS=$(aws s3 ls s3://assets.us.auth0.com/extensions/$EXTENSION_NAME/ | grep "$EXTENSION_NAME-$1.js")
-  CDN_EXISTS=$(aws s3 ls s3://assets.us.auth0.com/extensions/$EXTENSION_NAME/assets/ | grep "link.$1.min.css")
-  ADMIN_CDN_EXISTS=$(aws s3 ls s3://assets.us.auth0.com/extensions/$EXTENSION_NAME/assets/ | grep "admin.$1.min.css")
+  BUNDLE_EXISTS=$(aws s3 ls s3://assets.us.auth0.com/$EXTENSIONS_PATH/$EXTENSION_NAME/ | grep "$EXTENSION_NAME-$1.js")
+  CDN_EXISTS=$(aws s3 ls s3://assets.us.auth0.com/$EXTENSIONS_PATH/$EXTENSION_NAME/assets/ | grep "link.$1.min.css")
+  ADMIN_CDN_EXISTS=$(aws s3 ls s3://assets.us.auth0.com/$EXTENSIONS_PATH/$EXTENSION_NAME/assets/ | grep "admin.$1.min.css")
 
   if [ ! -z "$BUNDLE_EXISTS" ] && [ "$1" == "$CURRENT_VERSION" ]; then
     echo "There is already a $EXTENSION_NAME-$1.js in the cdn. Skipping cdn publish…"
   else
-    aws s3 cp build/bundle.js s3://assets.us.auth0.com/extensions/$EXTENSION_NAME/$EXTENSION_NAME-$1.js --region us-west-1 --acl public-read
+    aws s3 cp build/bundle.js s3://assets.us.auth0.com/$EXTENSIONS_PATH/$EXTENSION_NAME/$EXTENSION_NAME-$1.js --region us-west-1 --acl public-read
     echo "$EXTENSION_NAME-$1.js uploaded to the cdn"
   fi
 
   if [ ! -z "$CDN_EXISTS" ] && [ "$1" == "$CURRENT_VERSION" ]; then
     echo "There is already a link.$1.min.css in the cdn. Skipping cdn publish…"
   else
-    aws s3 cp dist/assets/link.$1.min.css s3://assets.us.auth0.com/extensions/$EXTENSION_NAME/assets/link.$1.min.css --region us-west-1 --cache-control "max-age=86400" --acl public-read
+    aws s3 cp dist/assets/link.$1.min.css s3://assets.us.auth0.com/$EXTENSIONS_PATH/$EXTENSION_NAME/assets/link.$1.min.css --region us-west-1 --cache-control "max-age=86400" --acl public-read
     echo "link.$1.min.css uploaded to the cdn"
   fi
 
   if [ ! -z "$ADMIN_CDN_EXISTS" ] && [ "$1" == "$CURRENT_VERSION" ]; then
     echo "There is already a admin.$1.min.css in the cdn. Skipping cdn publish…"
   else
-    aws s3 cp dist/assets/admin.$1.min.css s3://assets.us.auth0.com/extensions/$EXTENSION_NAME/assets/admin.$1.min.css --region us-west-1 --cache-control "max-age=86400" --acl public-read
+    aws s3 cp dist/assets/admin.$1.min.css s3://assets.us.auth0.com/$EXTENSIONS_PATH/$EXTENSION_NAME/assets/admin.$1.min.css --region us-west-1 --cache-control "max-age=86400" --acl public-read
     echo "admin.$1.min.css uploaded to the cdn"
   fi
 }

--- a/tools/cdn.sh
+++ b/tools/cdn.sh
@@ -4,10 +4,7 @@ EXTENSION_NAME="auth0-account-link"
 
 # Check if the current version is a beta version. If so, we'll
 # deploy to extensions/develop, rather than `extensions`.
-IS_BETA=$(echo "$CURRENT_VERSION" | grep -c "beta")
-
-# Determine base path depending on beta flag.
-if [ "$IS_BETA" -eq 1 ]; then
+if echo "$CURRENT_VERSION" | grep -q "beta"; then
   EXTENSIONS_PATH="extensions/develop"
   echo "Beta version detected ($CURRENT_VERSION). Using 'develop' CDN path."
 else


### PR DESCRIPTION
## ✏️ Changes

This PR allows publishing beta releases for testing. Beta releases will be published to the CDN at `s3://assets.us.auth0.com/extensions/develop/auth0-account-link/` rather than `s3://assets.us.auth0.com/extensions/auth0-account-link/`.

To publish a beta release, simply add a `publish-beta` tag to any PR 🪄.

[Successful action run](https://github.com/auth0-extensions/auth0-account-link-extension/actions/runs/17504178151)