### PR TITLE
fix: remove unused read:connections scope

### DIFF
--- a/integration/utils.js
+++ b/integration/utils.js
@@ -13,7 +13,7 @@ const mgmtApi = new ManagementClient({
   clientId: config.AUTH0_CLIENT_ID,
   clientSecret: config.AUTH0_CLIENT_SECRET,
   audience: `https://${config.AUTH0_DOMAIN}/api/v2/`,
-  scope: 'read:users create:users delete:users read:email_provider read:connections'
+  scope: 'read:users create:users delete:users read:email_provider'
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-account-link-extension",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Auth0 Account Link Extension",
   "main": "index.js",
   "engines": {

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 Account Link",
   "name": "auth0-account-link",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "preVersion": "3.0.0",
   "author": "auth0",
   "description":
@@ -25,7 +25,7 @@
     "onInstallPath": "/.extensions/on-install",
     "onUpdatePath": "/.extensions/on-install",
     "scopes":
-      "read:connections read:users read:rules create:rules update:rules delete:rules delete:clients read:custom_domains update:rules_configs delete:rules_configs"
+      "read:users read:rules create:rules update:rules delete:rules delete:clients read:custom_domains update:rules_configs delete:rules_configs"
   },
   "runtime": "node22"
 }


### PR DESCRIPTION
## ✏️ Changes

Remove the unused `read:connections` scope from the extension. The extension never calls the `/api/v2/connections` endpoint — connection names are obtained indirectly from user identities via the `read:users` scope. This reduces the extension's permission surface to follow the principle of least privilege.

- Removed `read:connections` from `webtask.json` scopes
- Removed `read:connections` from integration test ManagementClient scope
- Bumped version to 3.3.0 (minor bump since the declared permission set changes)

## 📷 Screenshots

N/A — no visual changes.

## 🔗 References

- Principle of least privilege: the extension should only request scopes it actually uses

## 🎯 Testing

Verified by grepping all source files — no code calls `getConnections()` or hits any `/api/v2/connections` endpoint. The only connection data used comes from `user.identities[].connection` which is served by the users API (`read:users`).

✅ This change has unit test coverage (existing tests unaffected)

🚫 This change has integration test coverage (integration tests don't call connections API)

🚫 This change has been tested for performance (no performance impact — config-only change)

## 🚀 Deployment

✅ This can be deployed any time

## 🎡 Rollout

Verify that the extension still installs, loads, and successfully links accounts after deployment. The account linking flow does not depend on the connections API.

## 🔥 Rollback

We will rollback if any tenant reports issues installing or updating the extension due to missing scope.

### 📄 Procedure

Revert this commit and redeploy. No data migration or state changes involved.

## 🖥 Appliance

This change is compatible with the Appliance — it only removes an unused scope declaration.