### PR TITLE
fix: remove unused read:connections scope

### DIFF
--- a/integration/utils.js
+++ b/integration/utils.js
@@ -13,7 +13,7 @@ const mgmtApi = new ManagementClient({
   clientId: config.AUTH0_CLIENT_ID,
   clientSecret: config.AUTH0_CLIENT_SECRET,
   audience: `https://${config.AUTH0_DOMAIN}/api/v2/`,
-  scope: 'read:users create:users delete:users read:email_provider read:connections'
+  scope: 'read:users create:users delete:users read:email_provider'
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-account-link-extension",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Auth0 Account Link Extension",
   "main": "index.js",
   "engines": {

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 Account Link",
   "name": "auth0-account-link",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "preVersion": "3.0.0",
   "author": "auth0",
   "description":
@@ -25,7 +25,7 @@
     "onInstallPath": "/.extensions/on-install",
     "onUpdatePath": "/.extensions/on-install",
     "scopes":
-      "read:connections read:users read:rules create:rules update:rules delete:rules delete:clients read:custom_domains update:rules_configs delete:rules_configs"
+      "read:users read:rules create:rules update:rules delete:rules delete:clients read:custom_domains update:rules_configs delete:rules_configs"
   },
   "runtime": "node22"
 }


### PR DESCRIPTION
## ✏️ Changes

Remove the unused `read:connections` scope from the extension. The extension never calls the `/api/v2/connections` endpoint — connection names are obtained indirectly from user identities via the `read:users` scope. This reduces the extension's permission surface to follow the principle of least privilege.

- Removed `read:connections` from `webtask.json` scopes
- Removed `read:connections` from integration test ManagementClient scope
- Bumped version to 3.3.0 (minor bump since the declared permission set changes)

## 📷 Screenshots

<img width="751" height="576" alt="Screenshot 2026-05-18 at 1 00 04 PM" src="https://github.com/user-attachments/assets/92031c3c-4a07-478f-aa74-05ebc030bc1e" />

## 🔗 References

- Principle of least privilege: the extension should only request scopes it actually uses

## 🎯 Testing

Verified by grepping all source files — no code calls `getConnections()` or hits any `/api/v2/connections` endpoint. The only connection data used comes from `user.identities[].connection` which is served by the users API (`read:users`).

### Pre-release installation

Installed the pre-release version by pointing the Auth0 Dashboard custom extension installer at a fork with the changes applied to its `master` branch:

```
https://github.com/gausnes/auth0-account-link-extension
```

Note: The dashboard fetches `webtask.json` from `raw.githubusercontent.com` which has a CDN cache of ~5-10 minutes. After pushing changes, wait for the cache to expire before installing.

### Manual end-to-end test

1. Created a user with email A on one connection
2. Used New Universal Login to sign up another user with the same email A on a different connection
3. Account linking prompt appeared asking to link the accounts
4. Accepted the link, logged in with the other user, and the operation succeeded

✅ This change has unit test coverage (existing tests unaffected)

✅ This change has been manually tested end-to-end

🚫 This change has been tested for performance (no performance impact — config-only change)

## 🚀 Deployment

✅ This can be deployed any time

## 🎡 Rollout

Verify that the extension still installs, loads, and successfully links accounts after deployment. The account linking flow does not depend on the connections API.

## 🔥 Rollback

We will rollback if any tenant reports issues installing or updating the extension due to missing scope.

### 📄 Procedure

Revert this commit and redeploy. No data migration or state changes involved.